### PR TITLE
ディレクトリ構成変更

### DIFF
--- a/components/bases/footer.vue
+++ b/components/bases/footer.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="footer">
+    <NuxtLink to="/scoreDisplay">Score</NuxtLink>
+    <br/>
+    <NuxtLink to="/top">Top</NuxtLink>
+  </div>
+</template>
+
+<style scoped>
+.footer{
+    text-align: center;
+    font-size: 32px;
+}
+</style>

--- a/components/bases/header.vue
+++ b/components/bases/header.vue
@@ -1,9 +1,9 @@
 <template>
-    <H1 class = "top">MX-Tsukuba</H1>
+    <H1 class = "header">MX-Tsukuba</H1>
 </template>
 
-<style>
-.top{
+<style scoped>
+.header{
     background-color: #fdfdfd;
     text-align: center;
     font-size: 3rem;

--- a/components/scoreDisplay/index.vue
+++ b/components/scoreDisplay/index.vue
@@ -1,0 +1,3 @@
+<template>
+  scoreDisplay Page
+</template>

--- a/components/scoreInput/enterGolfCourseName.vue
+++ b/components/scoreInput/enterGolfCourseName.vue
@@ -1,0 +1,10 @@
+<!-- モーダルで表示する -->
+<template>
+  <div>
+    <p>Enter golf course name.</p>
+    <input type="text" placeholder="course">   
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/components/scoreInput/index.vue
+++ b/components/scoreInput/index.vue
@@ -1,13 +1,7 @@
+<!-- 以前のコードほぼそのままなので上手く調節してください -->
 <template>
+  <EnterGolfCourseName/>
   <div>
-    <h1>MX-App</h1>
-
-    <div>
-      <p>
-        enter golf course info.
-        <input type="text" placeholder="course" v-model="playdata.course">
-      </p>      
-    </div>    
 
     <h2>{{ playdata.course }} course's Scores</h2>
     <ul v-if = "t_sample_kazuki && t_sample_kazuki.length">
@@ -35,6 +29,7 @@
 </template>
 
 <script setup lang="ts">
+import EnterGolfCourseName from './enterGolfCourseName.vue';
 import {type Database} from '~/types/database.types';
 const supabase = useSupabaseClient<Database>();
 

--- a/components/top/index.vue
+++ b/components/top/index.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    <p>直近の記録エリア</p>
+  </div>
+  <div>
+    <p>マッスルデータとスコアデータとの関連分析結果表示エリア
+    </p>
+  </div>
+  <div>
+    <NuxtLink to="../scoreInput">+</NuxtLink>
+  </div>
+</template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,12 @@
 <template>
-    <MXTsukuba />
-    <dev>
+    <Header/>
+    <div>
         <slot/>
-    </dev>
+    </div>
+    <Footer/>
 </template>
+
+<script setup lang="ts">
+import Header from '~/components/bases/header.vue';
+import Footer from '~/components/bases/footer.vue';
+</script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,4 +5,7 @@ export default defineNuxtConfig({
   supabase:{
     redirect:false
   },
+  router: {
+    base: `/top`,
+  },
 })

--- a/pages/scoreDisplay/index.vue
+++ b/pages/scoreDisplay/index.vue
@@ -1,0 +1,7 @@
+<template>
+  <scoreDisplay/>
+</template>
+
+<script setup lang="ts">
+import scoreDisplay from '~/components/scoreDisplay/index.vue';
+</script>

--- a/pages/scoreInput/index.vue
+++ b/pages/scoreInput/index.vue
@@ -1,0 +1,7 @@
+<template>
+  <scoreInput/>
+</template>
+
+<script setup lang="ts">
+import scoreInput from '~/components/scoreInput/index.vue';
+</script>

--- a/pages/top/index.vue
+++ b/pages/top/index.vue
@@ -1,0 +1,7 @@
+<template>
+  <top/>
+</template>
+
+<script setup lang="ts">
+import top from '~/components/top/index.vue';
+</script>


### PR DESCRIPTION
**ディレクトリ構成を以下のように変更**
・Layoutsにcomponents/bases/header.vueとfooter.vueを挿入
・フッターに各ログ画面へ飛べるようにした。とりあえず、ここではscoreDisplayに飛ぶ。
・デフォでtop/index.vueが表示される。これがホーム画面。
・ホーム画面から+で入力画面に飛ぶ。ここでは、とりあえずscoreInputのみに飛ぶ。
・scoreDisplayでは最初にゴルフ場入力モーダルon状態にして、入力完了したらモーダルoffにする。

　-イメージはFigmaを見てください。

**今回割と変更大きいので、レビュー必須で頼みます**
ディレクトリ構造もっといい案があったら、プルリク通さずに教えてください。